### PR TITLE
chg: implement plugin archiecture for Extractor, Transformer

### DIFF
--- a/symphony/__init__.py
+++ b/symphony/__init__.py
@@ -29,6 +29,8 @@ class ConfigurationError(Exception):
 
 class Symphony(object):
     def __init__(self, configuration: dict):
+        from symphony.utils import scan
+        scan('symphony.plugins')
         self.config = configuration
         self.output_dir = configuration.get('output_dir', '.')
         self.book_maker = create_book_maker(configuration)

--- a/symphony/etr_factory.py
+++ b/symphony/etr_factory.py
@@ -1,43 +1,37 @@
-from .etr import Extractor, Transformer, Render
-from .etr_avikdas import AvikdasExtractor
-from .etr_cs_rutgers_edu import CSRutgersEduExtractor
-from .etr_engineering_sportify import EngineeringSpotifyExtractor
-from .etr_fsblog import FsblogExtractor
-from .etr_increment import IncrementDotComExtractor
-from .etr_medium import MediumExtractor, MediumTransformer
-from .etr_morning import TheMorningPaperExtractor
-from .etr_preethikasireddy import PreethikasireddyExtractor
-from .etr_slack_engineering import SlackEngineeringExtractor
-from .etr_truyenfull import TruyenFullExtractor, TruyenFullTransformer
-from .etr_unintendedconsequences import UnintendedConsequencesExtractor
-from .etr_untools import UntoolsExtractor
+from .etr import Extractor, Transformer
+
+"""
+Dictionary of extractor
+"""
+__EXTRACTORS = {}
+
+"""
+Dictionary of transformer
+"""
+__TRANSFORMERS = {}
+
+
+def register_extractor(pattern):
+    def wrapper_class(arg):
+        __EXTRACTORS[pattern] = arg
+        return arg
+
+    return wrapper_class
+
+
+def register_transformer(pattern):
+    def wrapper_class(arg):
+        __TRANSFORMERS[pattern] = arg
+        return arg
+
+    return wrapper_class
 
 
 def create_extractor(url_path, bs):
-    if 'untools.co' in url_path:
-        return UntoolsExtractor(bs)
-    if 'unintendedconsequenc' in url_path:
-        return UnintendedConsequencesExtractor(bs)
-    if 'blog.acolyer.org' in url_path:
-        return TheMorningPaperExtractor(bs)
-    if '://fs.blog' in url_path:
-        return FsblogExtractor(bs)
-    if '://increment.com' in url_path:
-        return IncrementDotComExtractor(bs)
-    if '//slack.engineering' in url_path:
-        return SlackEngineeringExtractor(bs)
-    if '//medium.com' in url_path:
-        return MediumExtractor(bs)
-    if '//www.cs.rutgers.edu/~pxk/' in url_path:
-        return CSRutgersEduExtractor(bs)
-    if '//www.preethikasireddy.com' in url_path:
-        return PreethikasireddyExtractor(bs)
-    if '//engineering.atspotify.com' in url_path:
-        return EngineeringSpotifyExtractor(bs)
-    if '//truyenfull.vn' in url_path:
-        return TruyenFullExtractor(bs)
-    if '//avikdas.com' in url_path:
-        return AvikdasExtractor(bs)
+    for p in __EXTRACTORS.keys():
+        if p in url_path:
+            cls = __EXTRACTORS[p]
+            return cls(bs)
     return Extractor(bs)
 
 
@@ -46,15 +40,9 @@ def create_transformer(url_path, content, root):
         "src_url": url_path,
         "output_dir": root
     }
-    if 'untools.co' in url_path:
-        return Transformer(config, content)
-    if 'unintendedconsequenc' in url_path:
-        return Transformer(config, content)
-    if 'blog.acolyer.org' in url_path:
-        return Transformer(config, content)
-    if '//medium.com' in url_path:
-        return MediumTransformer(config, content)
-    if '//truyenfull.vn' in url_path:
-        return TruyenFullTransformer(config, content)
+    for p in __TRANSFORMERS.keys():
+        if p in url_path:
+            cls = __TRANSFORMERS[p]
+            return cls(config, content)
 
     return Transformer(config, content)

--- a/symphony/plugins/__init__.py
+++ b/symphony/plugins/__init__.py
@@ -1,0 +1,6 @@
+"""
+Plugin architecture, based on decorators
+
+References:
+    1. https://play.pixelblaster.ro/blog/2017/12/18/a-quick-and-dirty-mini-plugin-system-for-python/
+"""

--- a/symphony/plugins/etr_avikdas.py
+++ b/symphony/plugins/etr_avikdas.py
@@ -1,6 +1,8 @@
-from .etr import Extractor
+from symphony.etr import Extractor
+from symphony.etr_factory import register_extractor
 
 
+@register_extractor('avikdas.com')
 class AvikdasExtractor(Extractor):
     def internal_init(self):
         self.site = self.bs.body

--- a/symphony/plugins/etr_cs_rutgers_edu.py
+++ b/symphony/plugins/etr_cs_rutgers_edu.py
@@ -1,6 +1,8 @@
-from .etr import Extractor
+from symphony.etr import Extractor
+from symphony.etr_factory import register_extractor
 
 
+@register_extractor('www.cs.rutgers.edu/~pxk/')
 class CSRutgersEduExtractor(Extractor):
     def internal_init(self):
         self.site = self.bs.find('div', attrs={'id': 'main'})

--- a/symphony/plugins/etr_engineering_sportify.py
+++ b/symphony/plugins/etr_engineering_sportify.py
@@ -1,6 +1,8 @@
-from .etr import Extractor
+from symphony.etr import Extractor
+from symphony.etr_factory import register_extractor
 
 
+@register_extractor('engineering.atspotify.com')
 class EngineeringSpotifyExtractor(Extractor):
     def internal_init(self):
         self.site = self.bs.find('main', attrs={'id': 'main'})

--- a/symphony/plugins/etr_fsblog.py
+++ b/symphony/plugins/etr_fsblog.py
@@ -1,6 +1,8 @@
 from symphony.etr import Extractor
+from symphony.etr_factory import register_extractor
 
 
+@register_extractor('fs.blog')
 class FsblogExtractor(Extractor):
     def get_title(self):
         h1 = self.bs.find('h1', class_='entry-title')

--- a/symphony/plugins/etr_increment.py
+++ b/symphony/plugins/etr_increment.py
@@ -1,6 +1,8 @@
 from symphony.etr import Extractor
+from symphony.etr_factory import register_extractor
 
 
+@register_extractor('//increment.com')
 class IncrementDotComExtractor(Extractor):
     def get_title(self):
         title = self.bs.find('h1', class_='t-TitleSerif large title')

--- a/symphony/plugins/etr_medium.py
+++ b/symphony/plugins/etr_medium.py
@@ -1,8 +1,10 @@
 from bs4 import Tag
 
 from symphony.etr import Extractor, Transformer
+from symphony.etr_factory import register_extractor, register_transformer
 
 
+@register_extractor('//medium.com')
 class MediumExtractor(Extractor):
     def get_title(self):
         title = self.site.find('h1')
@@ -17,6 +19,7 @@ class MediumExtractor(Extractor):
         self.site = self.bs.find('article')
 
 
+@register_transformer('//medium.com')
 class MediumTransformer(Transformer):
     def transform_tag(self, tag: Tag, indent_level=0) -> str:
         if tag.name == 'figure' and 'paragraph-image' in tag.get('class'):

--- a/symphony/plugins/etr_morning.py
+++ b/symphony/plugins/etr_morning.py
@@ -1,6 +1,8 @@
 from symphony.etr import Extractor
+from symphony.etr_factory import register_extractor
 
 
+@register_extractor('//blog.acolyer.org')
 class TheMorningPaperExtractor(Extractor):
     def get_title(self):
         header = self.bs.find('h1', class_='entry-title')

--- a/symphony/plugins/etr_preethikasireddy.py
+++ b/symphony/plugins/etr_preethikasireddy.py
@@ -1,6 +1,8 @@
-from .etr import Extractor
+from symphony.etr import Extractor
+from symphony.etr_factory import register_extractor
 
 
+@register_extractor('//www.preethikasireddy.com')
 class PreethikasireddyExtractor(Extractor):
     def internal_init(self):
         self.site = self.bs.find('div', attrs={'id': 'Story'})

--- a/symphony/plugins/etr_slack_engineering.py
+++ b/symphony/plugins/etr_slack_engineering.py
@@ -1,6 +1,8 @@
 from symphony.etr import Extractor
+from symphony.etr_factory import register_extractor
 
 
+@register_extractor('//slack.engineering')
 class SlackEngineeringExtractor(Extractor):
     def get_title(self):
         title = self.bs.find('h1')

--- a/symphony/plugins/etr_truyenfull.py
+++ b/symphony/plugins/etr_truyenfull.py
@@ -2,9 +2,11 @@ import re
 
 from bs4 import Tag
 
-from .etr import Extractor, Transformer
+from symphony.etr import Extractor, Transformer
+from symphony.etr_factory import register_extractor, register_transformer
 
 
+@register_extractor('//truyenfull.vn')
 class TruyenFullExtractor(Extractor):
     def internal_init(self):
         self.site = self.bs.find('div', id='chapter-big-container')
@@ -16,6 +18,7 @@ class TruyenFullExtractor(Extractor):
         self.remove_tag(self.site, 'h2', attrs={})
 
 
+@register_transformer('//truyenfull.vn')
 class TruyenFullTransformer(Transformer):
     def transform_tag(self, tag: Tag, indent_level=0) -> str:
         if tag.name == 'br':

--- a/symphony/plugins/etr_unintendedconsequences.py
+++ b/symphony/plugins/etr_unintendedconsequences.py
@@ -1,6 +1,8 @@
 from symphony.etr import Extractor
+from symphony.etr_factory import register_extractor
 
 
+@register_extractor('unintendedconsequenc')
 class UnintendedConsequencesExtractor(Extractor):
     def get_title(self):
         return self.bs.find('h1').text

--- a/symphony/plugins/etr_untools.py
+++ b/symphony/plugins/etr_untools.py
@@ -1,8 +1,10 @@
 import re
 
 from symphony.etr import Extractor
+from symphony.etr_factory import register_extractor
 
 
+@register_extractor('//untools.co')
 class UntoolsExtractor(Extractor):
     def get_title(self):
         import re

--- a/symphony/utils.py
+++ b/symphony/utils.py
@@ -56,3 +56,23 @@ def slugify(value):
     value = unicodedata.normalize('NFKD', value).encode('ascii', 'ignore').decode('ascii')
     value = unicode(_slugify_strip_re.sub('', value).strip().lower())
     return _slugify_hyphenate_re.sub('-', value)
+
+
+def scan(namespace):
+    """ Scans the namespace for modules and imports them, to activate decorator
+    """
+
+    import importlib
+    import pkgutil
+
+    name = importlib.util.resolve_name(namespace, package=__package__)
+    spec = importlib.util.find_spec(name)
+
+    if spec is not None:
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+
+        for finder, name, ispkg in pkgutil.iter_modules(module.__path__):
+            spec = finder.find_spec(name)
+            module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(module)


### PR DESCRIPTION
What's changes:

* Move all extractors, transformers into a new package call `plugins`
* Create func decorator `register_extractor`, `register_transformer` to register Extractor and Transformer
* Add decorators to all extractors, transformers inside `plugins`
